### PR TITLE
Created config option for disabling plugin in certain worlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.imposter</groupId>
     <artifactId>LootableCorpses</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>LootableCorpses</name>

--- a/src/main/java/com/devConnor/lootableCorpses/listeners/CorpseListener.java
+++ b/src/main/java/com/devConnor/lootableCorpses/listeners/CorpseListener.java
@@ -4,6 +4,7 @@ import com.devConnor.lootableCorpses.LootableCorpses;
 import com.devConnor.lootableCorpses.instances.CorpseGui;
 import com.devConnor.lootableCorpses.managers.CorpseManager;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -30,23 +31,26 @@ public class CorpseListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerDeath(PlayerDeathEvent e) {
-        if (lootableCorpses.isPluginEnabled()) {
-            if(e.getKeepInventory()) return;
-            Player player = e.getEntity();
-            PlayerInventory inventory = player.getInventory();
-            List<ItemStack> drops = e.getDrops();
-            Set<ItemStack> dropSet = new HashSet<>(drops);
-            drops.clear();
-            for (int i = 0; i <= 40; i++) {
-                if (!dropSet.contains(inventory.getItem(i))) {
-                    inventory.clear(i);
-                }
-            }
-            corpseManager.createCorpse(player, inventory);
+        if (!lootableCorpses.isPluginEnabled()) return;
+        if (e.getKeepInventory()) return;
 
-            if (corpseManager.isInstantRespawnEnabled()) {
-                Bukkit.getScheduler().runTaskLater(lootableCorpses, () -> player.spigot().respawn(), 0L);
+        Player player = e.getEntity();
+        World playerWorld = player.getWorld();
+        if (corpseManager.isWorldBlacklisted(playerWorld.getName())) return;
+
+        PlayerInventory inventory = player.getInventory();
+        List<ItemStack> drops = e.getDrops();
+        Set<ItemStack> dropSet = new HashSet<>(drops);
+        drops.clear();
+        for (int i = 0; i <= 40; i++) {
+            if (!dropSet.contains(inventory.getItem(i))) {
+                inventory.clear(i);
             }
+        }
+        corpseManager.createCorpse(player, inventory);
+
+        if (corpseManager.isInstantRespawnEnabled()) {
+            Bukkit.getScheduler().runTaskLater(lootableCorpses, () -> player.spigot().respawn(), 0L);
         }
     }
 

--- a/src/main/java/com/devConnor/lootableCorpses/managers/CorpseManager.java
+++ b/src/main/java/com/devConnor/lootableCorpses/managers/CorpseManager.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.PlayerInventory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 public class CorpseManager {
@@ -36,6 +37,7 @@ public class CorpseManager {
     @Getter
     private final boolean killOnLeave;
 
+    private final List<String> blackListedWorlds;
     private final int CORPSE_LIFESPAN_MILLIS;
     private final boolean keepCorpsesAboveTheVoid;
 
@@ -48,6 +50,7 @@ public class CorpseManager {
         this.instantRespawnEnabled = ConfigManager.isInstantRespawnEnabled();
         this.killOnLeave = ConfigManager.shouldKillOnLeave();
         this.keepCorpsesAboveTheVoid = ConfigManager.isKeepCorpsesAboveTheVoid();
+        this.blackListedWorlds = ConfigManager.getBlacklistedWorlds();
 
         this.CORPSE_LIFESPAN_MILLIS = ConfigManager.getCorpseLifespanMillis();
 
@@ -98,6 +101,10 @@ public class CorpseManager {
         gui.open(player);
 
         setCorpseRemoverTimer(corpseEntity);
+    }
+
+    public boolean isWorldBlacklisted(String worldName) {
+        return blackListedWorlds.contains(worldName);
     }
 
     public void clear(boolean disregardTime) {

--- a/src/main/java/com/devConnor/lootableCorpses/utils/ConfigManager.java
+++ b/src/main/java/com/devConnor/lootableCorpses/utils/ConfigManager.java
@@ -3,6 +3,10 @@ package com.devConnor.lootableCorpses.utils;
 import com.devConnor.lootableCorpses.LootableCorpses;
 import org.bukkit.configuration.file.FileConfiguration;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ConfigManager {
 
     private static FileConfiguration config;
@@ -56,5 +60,16 @@ public class ConfigManager {
 
     public static boolean isKeepCorpsesAboveTheVoid() {
         return getBoolean("keep-corpses-above-the-void");
+    }
+
+    public static List<String> getBlacklistedWorlds() {
+        List<?> blacklistedWorlds = config.getList("blacklisted-worlds");
+        if (blacklistedWorlds != null) {
+            return blacklistedWorlds.stream()
+                    .map(obj -> (String) obj)
+                    .toList();
+        }
+
+        return new ArrayList<>();
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,3 +23,7 @@ inventory-title: "{player}'s inventory"
 
 # Set whether the corpse is generated above the Void when a player dies in the Void
 keep-corpses-above-the-void: true
+
+# Blacklisted worlds - disable lootable corpses in certain worlds
+blacklisted-worlds:
+  - world_nether


### PR DESCRIPTION
Add the following to config.yaml to disable LootableCorpses in certain worlds of your server:

```
# Blacklisted worlds - disable lootable corpses in certain worlds
blacklisted-worlds:
  - world_nether
```